### PR TITLE
Remove an editable name from Node Pool

### DIFF
--- a/ah/kubernetes_node_pools.go
+++ b/ah/kubernetes_node_pools.go
@@ -28,7 +28,7 @@ type PrivateProperties struct {
 type KubernetesNodePool struct {
 	Labels            Labels            `json:"labels,omitempty"`
 	ID                string            `json:"id,omitempty"`
-	Name              string            `json:"name"`
+	Name              string            `json:"name,omitempty"`
 	Type              string            `json:"type"`
 	CreatedAt         string            `json:"created_at,omitempty"`
 	Nodes             []KubernetesNodes `json:"nodes,omitempty"`
@@ -53,7 +53,6 @@ type CreateKubernetesNodePoolRequest struct {
 	PrivateProperties *PrivateProperties `json:"private_properties,omitempty"`
 	PublicProperties  *PublicProperties  `json:"public_properties,omitempty"`
 	Labels            *Labels            `json:"labels,omitempty"`
-	Name              string             `json:"name"`
 	Type              string             `json:"type"`
 	Count             int                `json:"count,omitempty"`
 	MinCount          int                `json:"min_count,omitempty"`
@@ -64,7 +63,6 @@ type CreateKubernetesNodePoolRequest struct {
 // UpdateKubernetesNodePoolRequest represents a request to update a node pool
 type UpdateKubernetesNodePoolRequest struct {
 	Labels    *Labels `json:"labels,omitempty"`
-	Name      string  `json:"name,omitempty"`
 	Count     int     `json:"count,omitempty"`
 	AutoScale bool    `json:"autoscale,omitempty"`
 	MinCount  int     `json:"min_count,omitempty"`

--- a/ah/kubernetes_node_pools_test.go
+++ b/ah/kubernetes_node_pools_test.go
@@ -10,7 +10,7 @@ import (
 
 const NodePoolPublicResponse = `{
 	"id": "e312aa01-d123-4a90-9c6d-f7641d2e4cc7",
-	"name": "test",
+	"name": "KNP100000",
 	"type": "public",
     "count": 1,
 	"labels": {"labels.websa.com/test": "test"},
@@ -32,7 +32,7 @@ const NodePoolPublicResponse = `{
 
 const NodePoolPrivateResponse = `{
 	"id": "7a41f73b-009d-4e52-9f20-edf4b8c5b072",
-	"name": "test",
+	"name": "KNP100000",
 	"type": "public",
     "count": 0,
 	"labels": {"labels.websa.com/test": "test"},
@@ -165,7 +165,6 @@ func TestNodePoolPublicCreate(t *testing.T) {
 	publicProperties := &PublicProperties{PlanID: 111111111}
 
 	request := &CreateKubernetesNodePoolRequest{
-		Name:             "test",
 		Type:             "public",
 		Count:            1,
 		PublicProperties: publicProperties,
@@ -209,7 +208,6 @@ func TestNodePoolPrivateCreate(t *testing.T) {
 	}
 
 	request := &CreateKubernetesNodePoolRequest{
-		Name:              "test",
 		Type:              "private",
 		Count:             1,
 		PrivateProperties: privateProperties,
@@ -239,7 +237,6 @@ func TestNodePoolUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	request := &UpdateKubernetesNodePoolRequest{
-		Name:      "test",
 		Count:     1,
 		AutoScale: false,
 	}


### PR DESCRIPTION
This merge request aims to remove the editable name field from the Websa k8s API Node Pool functionality. With the latest changes implemented, users will no longer be able to manually enter a name when creating or editing a Node Pool. Instead, the system will automatically generate a name for each Node Pool.

The rationale behind this update is to enforce consistency and improve system management. By having the system generate the name, it ensures that Node Pool names adhere to a standardized format and reduces the potential for naming conflicts or inconsistencies.